### PR TITLE
Dispatch change event when alignment is changed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,9 @@ class AlignmentBlockTune {
                 this.data = {
                     alignment: this.alignmentSettings[index].name
                 }
+
+		this.block?.dispatchChange();
+
                 elements.forEach((el, i) => {
                     const {name} = this.alignmentSettings[i];
                     el.classList.toggle(this.api.styles.settingsButtonActive, name === this.data.alignment);


### PR DESCRIPTION
There's a bug in the original repo for this EditorJS plugin, where if you click the alignment button, a change event is not triggered.

This commit introduces the fix from
https://github.com/kaaaaaaaaaaai/editorjs-alignment-blocktune/pull/13 to address this.